### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on: [ push ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/ruchernchong/number-format/security/code-scanning/1](https://github.com/ruchernchong/number-format/security/code-scanning/1)

To fix this issue, add a `permissions` block to the workflow at the top level, just below the workflow name. This will apply the least privileges necessary to all jobs by default unless overridden at job level. Since none of the jobs require write permissions to repository contents (they only run install/build/test/coverage reporting steps), the minimal necessary scope is `contents: read`. If later steps require other scopes (e.g., `pull-requests: write`), those can be added as needed. Edit the `.github/workflows/build.yml` file by adding the following block:
```yaml
permissions:
  contents: read
```
just after the `name:` line (before `on:`).

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
