### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ruchernchong/number-format/security/code-scanning/2](https://github.com/ruchernchong/number-format/security/code-scanning/2)

To fix the problem, we should explicitly set the `permissions` key for the `build` job to limit the GITHUB_TOKEN's access according to the least privilege principle. Since the `build` job does not need to modify contents or perform writes (only fetching code and running tests), we can set `permissions: contents: read` at the job level, similar to the permissions already applied to the `publish-npm` job. This change should be made by adding the following snippet under `build:` and before `runs-on: ubuntu-latest` (after line 8 and before line 9) in `.github/workflows/publish-package.yml`.

No new imports, methods, or external changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
