### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on: [ push ]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/ruchernchong/number-format/security/code-scanning/3](https://github.com/ruchernchong/number-format/security/code-scanning/3)

To fix the problem, add a `permissions` block that grants only the minimal required token permissions. In this case, since the jobs are fetching code, installing dependencies, running tests, and uploading coverage, they only need read access to repository contents. There is no evidence that any step requires broader permissions (e.g., no publishing, issue creation, etc.). The best fix is to add `permissions: contents: read` at the top level of the workflow file (after the `name` or before `jobs`), so that all jobs inherit this restricted scope by default. No functional changes will occur; it simply restricts the workflow's ability to use the `GITHUB_TOKEN` in a more privileged way.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
